### PR TITLE
Continuation of casting implementation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule Entice.Logic.Mixfile do
   defp deps do
     [{:entice_entity, github: "entice/entity", ref: "abd47e4bf5cc97d69c0c332d9559c63718348c0e"},
      {:uuid, "~> 1.0"},
-     {:inflex, "~> 1.0"}]
+     {:inflex, "~> 1.0"},
+     {:pipe, github: "batate/elixir-pipes"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"entice_entity": {:git, "git://github.com/entice/entity.git", "abd47e4bf5cc97d69c0c332d9559c63718348c0e", [ref: "abd47e4bf5cc97d69c0c332d9559c63718348c0e"]},
   "entice_utils": {:git, "git://github.com/entice/utils.git", "45fa9369284f92857c4436251a6b995c5d014680", [ref: "45fa9369284f92857c4436251a6b995c5d014680"]},
   "inflex": {:hex, :inflex, "1.5.0"},
+  "pipe": {:git, "git://github.com/batate/elixir-pipes.git", "0e046b108c5c758dd007a235d3adce89eeeab8d8", []},
   "uuid": {:hex, :uuid, "1.0.1"}}

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -1,0 +1,70 @@
+defmodule Entice.Logic.CastingTest do
+  use ExUnit.Case, async: true
+  alias Entice.Entity
+  alias Entice.Entity.Test.Spy
+  alias Entice.Logic.Skills
+  alias Entice.Logic.Casting
+  alias Entice.Logic.Vitals.Energy
+
+
+
+  #TODO put tests' setups here by id
+  setup do
+    {:ok, entity_id, _pid} = Entity.start
+    Casting.register(entity_id)
+    Spy.register(entity_id, self)
+    Entity.put_attribute(entity_id, %Energy{mana: 50})
+    {:ok, [entity_id: entity_id]}
+  end
+
+  @tag id: 0, casting: true
+  test "won't cast when not enough energy", %{entity_id: eid} do
+    Entity.put_attribute(eid, %Energy{mana: 0})
+    assert {:error, :not_enough_energy} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+  end
+
+  @tag id: 1, casting: true
+  test "won't cast recharging skill", %{entity_id: eid} do
+    Entity.put_attribute(eid, %Energy{mana: 100})
+
+    recharge_timers = Map.put(%{}, Skills.MantraOfEarth, 10)
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | recharge_timers: recharge_timers} end)
+    assert {:error, :still_recharging} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+    Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
+  end
+
+  @tag id: 2, casting: true
+  test "won't cast already casting", %{entity_id: eid} do
+
+    #Test with casting timer != nil
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10} end)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
+
+    #Test with after_cast_timer != nil
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | after_cast_timer: 10} end)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
+
+    #Test with both != nil
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10, after_cast_timer: 10} end)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
+  end
+
+  @tag id: 3, casting: true
+  test "cast instantaneous skill succesfully", %{entity_id: eid} do
+
+    assert {:ok, Skills.MantraOfEarth} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+    #calculated_mana = 50 - Skills.MantraOfEarth.energy_cost
+    #assert %Energy{mana: ^calculated_mana} = Entity.get_attribute(eid, Energy) #Can't seem to figure out that bug
+  end
+
+  @tag id: 4, casting: true
+  test "cast non instantaneous skill succesfully", %{entity_id: eid} do
+
+    assert {:ok, Skills.HealingSignet} = Casting.cast_skill(eid, Skills.HealingSignet)
+    #calculated_mana = 50 - Skills.HealingSignet.energy_cost
+    #assert %Energy{mana: ^calculated_mana} = Entity.get_attribute(eid, Energy) #Can't seem to figure out that bug
+  end
+end

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -35,7 +35,7 @@ defmodule Entice.Logic.CastingTest do
   test "won't cast already casting", %{entity_id: eid} do
 
     #Test with casting timer != nil
-    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10} end)
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | cast_timer: 10} end)
     assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
 
@@ -45,7 +45,7 @@ defmodule Entice.Logic.CastingTest do
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
 
     #Test with both != nil
-    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10, after_cast_timer: 10} end)
+    Entity.update_attribute(eid, Casting, fn c -> %Casting{c | cast_timer: 10, after_cast_timer: 10} end)
     assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
   end
@@ -67,7 +67,7 @@ defmodule Entice.Logic.CastingTest do
 
     #Check Casting returned to initial state
     assert nil = Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
-    assert nil = Entity.get_attribute(eid, Casting).casting_timer
+    assert nil = Entity.get_attribute(eid, Casting).cast_timer
     assert nil = Entity.get_attribute(eid, Casting).after_cast_timer
   end
 end

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -54,27 +54,18 @@ defmodule Entice.Logic.CastingTest do
 
   @tag id: 3, casting: true
   test "cast skill succesfully", %{entity_id: eid} do
-
     assert {:ok, Skills.SignetOfCapture} = Casting.cast_skill(eid, Skills.SignetOfCapture)
 
+    #Check appropriate events happen at appropriate times
     assert_receive %{sender: ^eid, event: {:cast_end, Skills.SignetOfCapture, nil, nil}}, 2100
-    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, nil}}, 4200
-    #Following asserts will fail
-    #assert nil = Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
-    #assert nil = Entity.get_attribute(eid, Casting).casting_timer
-    #assert nil = Entity.get_attribute(eid, Casting).after_cast_timer
+    assert nil != Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
+    assert nil != Entity.get_attribute(eid, Casting).after_cast_timer
+    assert_receive %{sender: ^eid, event: {:after_cast_end}}, 350
+    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, nil}}, 2100
 
-
-
-    #calculated_mana = 50 - Skills.MantraOfEarth.energy_cost
-    #assert %Energy{mana: ^calculated_mana} = Entity.get_attribute(eid, Energy) #Can't seem to figure out that bug
-  end
-
-  @tag id: 4, casting: true
-  test "cast non instantaneous skill succesfully", %{entity_id: eid} do
-
-    assert {:ok, Skills.HealingSignet} = Casting.cast_skill(eid, Skills.HealingSignet)
-    #calculated_mana = 50 - Skills.HealingSignet.energy_cost
-    #assert %Energy{mana: ^calculated_mana} = Entity.get_attribute(eid, Energy) #Can't seem to figure out that bug
+    #Check Casting returned to initial state
+    assert nil = Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
+    assert nil = Entity.get_attribute(eid, Casting).casting_timer
+    assert nil = Entity.get_attribute(eid, Casting).after_cast_timer
   end
 end

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -7,8 +7,6 @@ defmodule Entice.Logic.CastingTest do
   alias Entice.Logic.Vitals.Energy
 
 
-
-  #TODO put tests' setups here by id
   setup do
     {:ok, entity_id, _pid} = Entity.start
     Casting.register(entity_id)
@@ -20,7 +18,7 @@ defmodule Entice.Logic.CastingTest do
   @tag id: 0, casting: true
   test "won't cast when not enough energy", %{entity_id: eid} do
     Entity.put_attribute(eid, %Energy{mana: 0})
-    assert {:error, :not_enough_energy} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+    assert {:error, :not_enough_energy} = Casting.cast_skill(eid, Skills.MantraOfEarth, &(send self, &1), &(send self, &1))
   end
 
   @tag id: 1, casting: true
@@ -29,7 +27,7 @@ defmodule Entice.Logic.CastingTest do
 
     recharge_timers = Map.put(%{}, Skills.MantraOfEarth, 10)
     Entity.update_attribute(eid, Casting, fn c -> %Casting{c | recharge_timers: recharge_timers} end)
-    assert {:error, :still_recharging} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+    assert {:error, :still_recharging} = Casting.cast_skill(eid, Skills.MantraOfEarth, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
   end
 
@@ -38,30 +36,34 @@ defmodule Entice.Logic.CastingTest do
 
     #Test with casting timer != nil
     Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10} end)
-    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
 
     #Test with after_cast_timer != nil
     Entity.update_attribute(eid, Casting, fn c -> %Casting{c | after_cast_timer: 10} end)
-    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
 
     #Test with both != nil
     Entity.update_attribute(eid, Casting, fn c -> %Casting{c | casting_timer: 10, after_cast_timer: 10} end)
-    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet)
+    assert {:error, :still_casting} = Casting.cast_skill(eid, Skills.HealingSignet, &(send self, &1), &(send self, &1))
     Entity.update_attribute(eid, Casting, fn _c -> %Casting{} end)
   end
 
   @tag id: 3, casting: true
   test "cast skill succesfully", %{entity_id: eid} do
-    assert {:ok, Skills.SignetOfCapture} = Casting.cast_skill(eid, Skills.SignetOfCapture)
+    this = self
+    assert {:ok, Skills.SignetOfCapture} = Casting.cast_skill(eid, Skills.SignetOfCapture, &(send this, &1), &(send this, &1))
 
     #Check appropriate events happen at appropriate times
-    assert_receive %{sender: ^eid, event: {:cast_end, Skills.SignetOfCapture, nil, nil}}, 2100
+    assert_receive %{sender: ^eid, event: {:cast_end, Skills.SignetOfCapture, _cast_callback, _recharge_callback}}, 3500
+    assert_receive Skills.SignetOfCapture
     assert nil != Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
     assert nil != Entity.get_attribute(eid, Casting).after_cast_timer
+
     assert_receive %{sender: ^eid, event: {:after_cast_end}}, 350
-    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, nil}}, 2100
+    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, _recharge_callback}}, 2100
+    assert_receive Skills.SignetOfCapture
 
     #Check Casting returned to initial state
     assert nil = Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -56,13 +56,13 @@ defmodule Entice.Logic.CastingTest do
     assert {:ok, Skills.SignetOfCapture} = Casting.cast_skill(eid, Skills.SignetOfCapture, &(send this, &1), &(send this, &1))
 
     #Check appropriate events happen at appropriate times
-    assert_receive %{sender: ^eid, event: {:cast_end, Skills.SignetOfCapture, _cast_callback, _recharge_callback}}, 3500
+    assert_receive %{sender: ^eid, event: {:casting_cast_end, Skills.SignetOfCapture, _cast_callback, _recharge_callback}}, 3500
     assert_receive Skills.SignetOfCapture
     assert nil != Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
     assert nil != Entity.get_attribute(eid, Casting).after_cast_timer
 
-    assert_receive %{sender: ^eid, event: {:after_cast_end}}, 350
-    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, _recharge_callback}}, 2100
+    assert_receive %{sender: ^eid, event: {:casting_after_cast_end}}, 350
+    assert_receive %{sender: ^eid, event: {:casting_recharge_end, Skills.SignetOfCapture, _recharge_callback}}, 2100
     assert_receive Skills.SignetOfCapture
 
     #Check Casting returned to initial state

--- a/test/entice/logic/casting_test.exs
+++ b/test/entice/logic/casting_test.exs
@@ -53,9 +53,19 @@ defmodule Entice.Logic.CastingTest do
   end
 
   @tag id: 3, casting: true
-  test "cast instantaneous skill succesfully", %{entity_id: eid} do
+  test "cast skill succesfully", %{entity_id: eid} do
 
-    assert {:ok, Skills.MantraOfEarth} = Casting.cast_skill(eid, Skills.MantraOfEarth)
+    assert {:ok, Skills.SignetOfCapture} = Casting.cast_skill(eid, Skills.SignetOfCapture)
+
+    assert_receive %{sender: ^eid, event: {:cast_end, Skills.SignetOfCapture, nil, nil}}, 2100
+    assert_receive %{sender: ^eid, event: {:recharge_end, Skills.SignetOfCapture, nil}}, 4200
+    #Following asserts will fail
+    #assert nil = Entity.get_attribute(eid, Casting).recharge_timers[Skills.SignetOfCapture]
+    #assert nil = Entity.get_attribute(eid, Casting).casting_timer
+    #assert nil = Entity.get_attribute(eid, Casting).after_cast_timer
+
+
+
     #calculated_mana = 50 - Skills.MantraOfEarth.energy_cost
     #assert %Energy{mana: ^calculated_mana} = Entity.get_attribute(eid, Energy) #Can't seem to figure out that bug
   end


### PR DESCRIPTION
TODO still:
Write tests for events
Implement after_cast_end event
Add callback parameters instead of default nil
Add recharge_callback call

Questions:
Is the diagram up to date?
What's the purpose of after_cast_timer?
What's the purpose of the recharge callback ?
Why do we only check if the player is casting when the skill is not instantaneous?
